### PR TITLE
fixes for R and some support for test_performance_sims

### DIFF
--- a/conda_packages.txt
+++ b/conda_packages.txt
@@ -256,6 +256,7 @@ r-gridextra=2.3=r43hc72bb7e_1005
 r-gtable=0.3.4=r43hc72bb7e_0
 r-hardhat=1.3.1=r43hc72bb7e_0
 r-haven=2.5.4=r43ha503ecb_0
+r-here=1.0.1=r43hc72bb7e_2
 r-hexbin=1.28.3=r43h61816a4_1
 r-highr=0.10=r43hc72bb7e_1
 r-hms=1.1.3=r43hc72bb7e_1
@@ -349,6 +350,7 @@ r-rlang=1.1.3=r43ha503ecb_0
 r-rmarkdown=2.26=r43hc72bb7e_0
 r-rmpi=0.7_2=r43hd1460b4_0
 r-rpart=4.1.23=r43h57805ef_0
+r-rprojroot=2.0.4=r43hc72bb7e_0
 r-rstudioapi=0.16.0=r43hc72bb7e_0
 r-rvest=1.0.4=r43hc72bb7e_0
 r-sass=0.4.9=r43ha503ecb_0

--- a/conda_packages.txt
+++ b/conda_packages.txt
@@ -320,6 +320,7 @@ r-quantmod=0.4.26=r43hc72bb7e_0
 r-r6=2.5.1=r43hc72bb7e_2
 r-ragg=1.3.0=r43h73ae6e3_0
 r-randomforest=4.7_1.1=r43h61816a4_2
+r-randomizr=1.0.0=r43h57805ef_0
 r-rappdirs=0.3.3=r43h57805ef_2
 r-rbibutils=2.2.16=r43h57805ef_0
 r-rbokeh=0.5.2=r43hc72bb7e_3

--- a/containers/bowers-dev-env.def
+++ b/containers/bowers-dev-env.def
@@ -31,6 +31,7 @@ Stage: build
 
     # user-specific dev tools
     apt-get install -y --no-install-recommends \
+        graphviz \
         htop \
         neovim \
         ripgrep \

--- a/containers/bowers-dev-env.def
+++ b/containers/bowers-dev-env.def
@@ -25,9 +25,14 @@ Stage: build
         libcurl4-openssl-dev \
         libssl-dev \
         libxml2-dev \
+        locales \
         openssh-client \
         unzip \
         wget
+
+    # set locales specifically or R will segfault
+    echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
+    locale-gen && update-locale LANG=en_US.UTF-8
 
     # user-specific dev tools
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
There was a problem with R segfaulting immediately. R is apparently super-vigilant about checking the OS locale setting so I added that explicitly to the container definition file.

I did some preliminary testing by launching the container as a shell and trying to make things in test_performance_sims. Discovered it was missing GraphViz for: 

`Singularity> make makefile.plots` 

and was missing some R packages for: 

`Singularity> make Data/make_test_data.done`

That was as far as I got before it got angry about wanting `manytestr`.

Tested on both my local machine and the ICC.
