### PR TITLE
Minimal manytestsr container

### DIFF
--- a/containers/bowers-prod-env.def
+++ b/containers/bowers-prod-env.def
@@ -47,11 +47,14 @@ Stage: build
 
     # base R install
     # packages unavailable through Mamba: dataPreparation
+    # remotes gets installed through Mamba, but it is not available during
+    # %post, so we explicitly install it, and then install manytestsr
     apt-get install -y --no-install-recommends \
         r-base \
         r-base-dev && \
         mkdir -p /opt/R/x86_64-pc-linux-gnu-library/4.3 && \
-        R --no-echo -e 'install.packages("dataPreparation", "/opt/R/x86_64-pc-linux-gnu-library/4.3", quiet=TRUE)'
+        R --no-echo -e 'install.packages("dataPreparation", "/opt/R/x86_64-pc-linux-gnu-library/4.3", quiet=TRUE)' && \
+        R --no-echo -e 'install.packages("remotes", "/opt/R/x86_64-pc-linux-gnu-library/4.3", quiet=TRUE); remotes::install_github("bowers-illinois-edu/manytestsr", quiet=TRUE, upgrade="never")'
 
     # Miniforge, also installs Python, Mamba, Conda
     # stolen from various SO answers, representative one at 77441093

--- a/containers/bowers-prod-env.def
+++ b/containers/bowers-prod-env.def
@@ -43,19 +43,6 @@ Stage: build
         tmux \
         zsh
 
-    # MVM: unclear if CRAN is needed 
-
-    # base R install
-    # packages unavailable through Mamba: dataPreparation
-    # remotes gets installed through Mamba, but it is not available during
-    # %post, so we explicitly install it, and then install manytestsr
-    apt-get install -y --no-install-recommends \
-        r-base \
-        r-base-dev && \
-        mkdir -p /opt/R/x86_64-pc-linux-gnu-library/4.3 && \
-        R --no-echo -e 'install.packages("dataPreparation", "/opt/R/x86_64-pc-linux-gnu-library/4.3", quiet=TRUE)' && \
-        R --no-echo -e 'install.packages("remotes", "/opt/R/x86_64-pc-linux-gnu-library/4.3", quiet=TRUE); remotes::install_github("bowers-illinois-edu/manytestsr", quiet=TRUE, upgrade="never")'
-
     # Miniforge, also installs Python, Mamba, Conda
     # stolen from various SO answers, representative one at 77441093
     readonly mamba_installer="Mambaforge-$(uname)-$(uname -m).sh"
@@ -66,12 +53,16 @@ Stage: build
     rm "${mamba_installer}"
     export PATH="${mamba_prefix}/bin:$PATH"
 
+    # using mamba to install R because later it seems to find my R, shadowing of /usr/bin?
+    mamba install r
+
     # MVM: adapted from geniac.readthedocs.io
     # by default launching an interactive Singularity shell does NOT
     # execute any profile or rc files. 
     # The idea is to create a globally excessible zshrc which can be 
     # sourced in %environment. It works, except that $CONDA_PROMPT_MODIFIER
     # does NOT get applied to the prompt.
+
     mkdir -p /opt/etc
     git clone https://github.com/bowers-illinois-edu/linux_work_environment.git && \
         cd linux_work_environment && \
@@ -104,10 +95,11 @@ Stage: build
     # source the global zshrc created above
     export SHELL=/bin/zsh
     source /opt/etc/zshrc
-    
+   
+    # MVM - this was experimental when installing dataPreparation 
     # make sure to NOT pick up an R_LIBS which might be 
     # accessible if $HOME is mapped
-    export R_LIBS_USER=/opt/R/x86_64-pc-linux-gnu-library/4.3
+    #export R_LIBS_USER=/opt/R/x86_64-pc-linux-gnu-library/4.3
 
 %runscript
     exec /bin/zsh "$@"

--- a/containers/bowers-prod-env.def
+++ b/containers/bowers-prod-env.def
@@ -51,7 +51,7 @@ Stage: build
         r-base \
         r-base-dev && \
         mkdir -p /opt/R/x86_64-pc-linux-gnu-library/4.3 && \
-        R --no-echo -e 'install.packages("dataPreparation", "/opt/R/x86_64-pc-linux-gnu-library/4.3", quiet=TRUE)'       
+        R --no-echo -e 'install.packages("dataPreparation", "/opt/R/x86_64-pc-linux-gnu-library/4.3", quiet=TRUE)'
 
     # Miniforge, also installs Python, Mamba, Conda
     # stolen from various SO answers, representative one at 77441093

--- a/containers/bowers-prod-env.def
+++ b/containers/bowers-prod-env.def
@@ -43,6 +43,19 @@ Stage: build
         tmux \
         zsh
 
+    # MVM: unclear if CRAN is needed 
+
+    # base R install
+    # packages unavailable through Mamba: dataPreparation
+    # remotes gets installed through Mamba, but it is not available during
+    # %post, so we explicitly install it, and then install manytestsr
+    apt-get install -y --no-install-recommends \
+        r-base \
+        r-base-dev && \
+        mkdir -p /opt/R/x86_64-pc-linux-gnu-library/4.3 && \
+        R --no-echo -e 'install.packages("dataPreparation", "/opt/R/x86_64-pc-linux-gnu-library/4.3", quiet=TRUE)' && \
+        R --no-echo -e 'install.packages("remotes", "/opt/R/x86_64-pc-linux-gnu-library/4.3", quiet=TRUE); remotes::install_github("bowers-illinois-edu/manytestsr", quiet=TRUE, upgrade="never")'
+
     # Miniforge, also installs Python, Mamba, Conda
     # stolen from various SO answers, representative one at 77441093
     readonly mamba_installer="Mambaforge-$(uname)-$(uname -m).sh"
@@ -53,16 +66,12 @@ Stage: build
     rm "${mamba_installer}"
     export PATH="${mamba_prefix}/bin:$PATH"
 
-    # using mamba to install R because later it seems to find my R, shadowing of /usr/bin?
-    mamba install r
-
     # MVM: adapted from geniac.readthedocs.io
     # by default launching an interactive Singularity shell does NOT
     # execute any profile or rc files. 
     # The idea is to create a globally excessible zshrc which can be 
     # sourced in %environment. It works, except that $CONDA_PROMPT_MODIFIER
     # does NOT get applied to the prompt.
-
     mkdir -p /opt/etc
     git clone https://github.com/bowers-illinois-edu/linux_work_environment.git && \
         cd linux_work_environment && \
@@ -95,11 +104,10 @@ Stage: build
     # source the global zshrc created above
     export SHELL=/bin/zsh
     source /opt/etc/zshrc
-   
-    # MVM - this was experimental when installing dataPreparation 
+    
     # make sure to NOT pick up an R_LIBS which might be 
     # accessible if $HOME is mapped
-    #export R_LIBS_USER=/opt/R/x86_64-pc-linux-gnu-library/4.3
+    export R_LIBS_USER=/opt/R/x86_64-pc-linux-gnu-library/4.3
 
 %runscript
     exec /bin/zsh "$@"

--- a/containers/bowers-prod-env.def
+++ b/containers/bowers-prod-env.def
@@ -47,14 +47,11 @@ Stage: build
 
     # base R install
     # packages unavailable through Mamba: dataPreparation
-    # remotes gets installed through Mamba, but it is not available during
-    # %post, so we explicitly install it, and then install manytestsr
     apt-get install -y --no-install-recommends \
         r-base \
         r-base-dev && \
         mkdir -p /opt/R/x86_64-pc-linux-gnu-library/4.3 && \
-        R --no-echo -e 'install.packages("dataPreparation", "/opt/R/x86_64-pc-linux-gnu-library/4.3", quiet=TRUE)' && \
-        R --no-echo -e 'install.packages("remotes", "/opt/R/x86_64-pc-linux-gnu-library/4.3", quiet=TRUE); remotes::install_github("bowers-illinois-edu/manytestsr", quiet=TRUE, upgrade="never")'
+        R --no-echo -e 'install.packages("dataPreparation", "/opt/R/x86_64-pc-linux-gnu-library/4.3", quiet=TRUE)'       
 
     # Miniforge, also installs Python, Mamba, Conda
     # stolen from various SO answers, representative one at 77441093

--- a/containers/minimal.def
+++ b/containers/minimal.def
@@ -41,6 +41,8 @@ Stage: build
     echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
     locale-gen && update-locale LANG=en_US.UTF-8
 
+    apt-get install -y --no-install-recommends r-base r-base-dev
+
     # Miniforge, also installs Python, Mamba, Conda
     # stolen from various SO answers, representative one at 77441093
     readonly mamba_installer="Mambaforge-$(uname)-$(uname -m).sh"

--- a/containers/minimal.def
+++ b/containers/minimal.def
@@ -24,6 +24,7 @@ Stage: build
         git \
         gsl-bin \
         libcurl4-openssl-dev \
+        libgmp-dev \
         libssl-dev \
         libtiff-dev \
         libxml2-dev \

--- a/containers/minimal.def
+++ b/containers/minimal.def
@@ -24,6 +24,7 @@ Stage: build
         git \
         gsl-bin \
         libcurl4-openssl-dev \
+        libfreetype-dev \
         libgmp-dev \
         libssl-dev \
         libtiff-dev \

--- a/containers/minimal.def
+++ b/containers/minimal.def
@@ -43,24 +43,9 @@ Stage: build
 
     apt-get install -y --no-install-recommends r-base r-base-dev
 
-    # Miniforge, also installs Python, Mamba, Conda
-    # stolen from various SO answers, representative one at 77441093
-    readonly mamba_installer="Mambaforge-$(uname)-$(uname -m).sh"
-    readonly mamba_version="24.1.2-0"
-    readonly mamba_prefix="/opt/mamba"
-    wget "https://github.com/conda-forge/miniforge/releases/download/${mamba_version}/${mamba_installer}"
-    bash "${mamba_installer}" -b -p "${mamba_prefix}"
-    rm "${mamba_installer}"
-    export PATH="${mamba_prefix}/bin:$PATH"
-
-    # using mamba to install R because later it seems to find my R, shadowing of /usr/bin?
-    mamba install r
-
-    # manytestsr repo requires remotes::install_github()
-    mamba install r-remotes
-
     # This increases the build time substantially.
-    R --no-echo -e 'remotes::install_github("bowers-illinois-edu/manytestsr", quiet=FALSE, upgrade="never")'
+    R --no-echo -e 'install.packages("remotes")'
+    R --no-echo -e 'remotes::install_github("bowers-illinois-edu/manytestsr", upgrade="always")'
    
     # clean up
     rm -rf /var/lib/apt/lists/*

--- a/containers/minimal.def
+++ b/containers/minimal.def
@@ -24,6 +24,7 @@ Stage: build
         git \
         libcurl4-openssl-dev \
         libssl-dev \
+        libtiff-dev \
         libxml2-dev \
         locales \
         openssh-client \

--- a/containers/minimal.def
+++ b/containers/minimal.def
@@ -22,6 +22,7 @@ Stage: build
         cmake \
         curl \
         git \
+        gsl-bin \
         libcurl4-openssl-dev \
         libssl-dev \
         libtiff-dev \

--- a/containers/minimal.def
+++ b/containers/minimal.def
@@ -1,0 +1,62 @@
+Bootstrap: library
+From: ubuntu:22.04
+Stage: build
+
+# post: commands executed in container, after base OS install
+%post 
+
+    # this is a known annoyance: without these, the build will halt and
+    # wait for timezone info, but is also non-responsive, so it hangs.
+    export DEBIAN_FRONTEND=noninteractive
+    export TZ=America/Chicago
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+    apt-get -y update
+    apt-get -y upgrade
+
+    # standard Ubuntu dev tools
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        bzip2 \
+        ca-certificates \
+        cmake \
+        curl \
+        git \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libxml2-dev \
+        locales \
+        openssh-client \
+        unzip \
+        wget
+
+    # set locales specifically or R will segfault
+    echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
+    locale-gen && update-locale LANG=en_US.UTF-8
+
+    # Miniforge, also installs Python, Mamba, Conda
+    # stolen from various SO answers, representative one at 77441093
+    readonly mamba_installer="Mambaforge-$(uname)-$(uname -m).sh"
+    readonly mamba_version="24.1.2-0"
+    readonly mamba_prefix="/opt/mamba"
+    wget "https://github.com/conda-forge/miniforge/releases/download/${mamba_version}/${mamba_installer}"
+    bash "${mamba_installer}" -b -p "${mamba_prefix}"
+    rm "${mamba_installer}"
+    export PATH="${mamba_prefix}/bin:$PATH"
+
+    # using mamba to install R because later it seems to find my R, shadowing of /usr/bin?
+    mamba install r
+
+    # manytestsr repo requires remotes::install_github()
+    mamba install r-remotes
+
+    # This increases the build time substantially.
+    R --no-echo -e 'remotes::install_github("bowers-illinois-edu/manytestsr", quiet=FALSE, upgrade="never")'
+   
+    # clean up
+    rm -rf /var/lib/apt/lists/*
+    apt-get clean
+
+%labels
+    Author mvanmoer
+    Version v0.0.1

--- a/containers/minimal.def
+++ b/containers/minimal.def
@@ -22,10 +22,13 @@ Stage: build
         cmake \
         curl \
         git \
-        gsl-bin \
         libcurl4-openssl-dev \
+        libfontconfig1-dev \
         libfreetype-dev \
+        libfreetype6 \
+        libfreetype6-dev \
         libgmp-dev \
+        libgsl-dev \
         libssl-dev \
         libtiff-dev \
         libxml2-dev \


### PR DESCRIPTION
I'm running into bootstrapping issues getting `manytestsr` to build in the original definition file, so as a sanity check I made a minimal container that only builds `manytestsr` with minimal dependencies.

- added some apt packages needed by things like `systemfonts` 
- installing R through `apt` instead of `mamba`
- installing `remotes` and `manytestsr` with R one-liners

