### PR TITLE
Now runs devtools::document() and devtools::check() on ICC

### DIFF
--- a/containers/minimal.def
+++ b/containers/minimal.def
@@ -51,6 +51,10 @@ Stage: build
     rm -rf /var/lib/apt/lists/*
     apt-get clean
 
+%test
+    # verifies that R can see and load manytestsr
+    R -e "library(manytestsr)"
+
 %labels
     Author mvanmoer
     Version v0.0.1

--- a/containers/minimal.def
+++ b/containers/minimal.def
@@ -46,7 +46,16 @@ Stage: build
     apt-get install -y --no-install-recommends r-base r-base-dev
 
     # This increases the build time substantially.
-    R --no-echo -e 'install.packages("remotes")'
+    # explicit use or /usr/lib/R/library - default is
+    # /usr/local/lib/R/site-library and either testthat or devtools insists on
+    # checking .Library instead of .libPaths()
+    R --no-echo -e 'install.packages("remotes", "/usr/lib/R/library")'
+    R --no-echo -e 'install.packages("pkgdown", "/usr/lib/R/library")'
+    R --no-echo -e 'install.packages("devtools", "/usr/lib/R/library")'
+    R --no-echo -e 'install.packages("here", "/usr/lib/R/library")'
+    R --no-echo -e 'install.packages("dtplyr", "/usr/lib/R/library")'
+    R --no-echo -e 'install.packages("conflicted", "/usr/lib/R/library")'
+    R --no-echo -e 'install.packages("bench", "/usr/lib/R/library")'
     R --no-echo -e 'remotes::install_github("bowers-illinois-edu/manytestsr", upgrade="always")'
    
     # clean up

--- a/containers/minimal.def
+++ b/containers/minimal.def
@@ -27,8 +27,10 @@ Stage: build
         libfreetype-dev \
         libfreetype6 \
         libfreetype6-dev \
+        libfribidi-dev \
         libgmp-dev \
         libgsl-dev \
+        libharfbuzz-dev \
         libssl-dev \
         libtiff-dev \
         libxml2-dev \


### PR DESCRIPTION
Mainly additional pre-reqs in order to run `devtools::document()` and `devtools::check()` inside a manytestsr repo on the Illinois Campus Cluster. I've cloned manytestsr into `/projects/illinois/las/pol/jwbowers/manytestsr` and I've altered the `interactive-job.sh` in `../jwbowers` slightly. By default it will try an IllinoisComputes queue, but one can also supply a queue on the command line.

Process:
`$ ssh cc-login`

`[cc-login] $ cd /projects/illinois/las/pol/jwbowers/`

`[cc-login] $ ./interactive-job.sh`

`[compute] $ singularity shell --bind /projects minimal.sif`

`Singularity> R`

`R> setwd("manytestsr")`

`R> devtools::document()`

`R> devtools::check()`

`0 errors v | 5 warnings x | 2 notes x`
