### PR TITLE
Update minimal.def for building sandbox on Campus Cluster

### DIFF
--- a/containers/minimal.def
+++ b/containers/minimal.def
@@ -1,4 +1,4 @@
-Bootstrap: library
+BootStrap: docker
 From: ubuntu:22.04
 Stage: build
 


### PR DESCRIPTION
I had been building sandboxes and .sif's locally, and then just copying the sif's to CC as needed. Rob has run into issues with that workflow so I figured out a way to build it directly on the CC without needing sudo.

1. change to bootstrap from docker instead of library
2. on the CC, build in /tmp on a login node.