### PR TITLE
Updated documentation for building containers on ICC

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -1,11 +1,11 @@
-# Singularity Container Info
+# Apptainer Container Info
 
 * minimal.def: Definition file to create a minimal container for running manytestsr and test_performance_sims
 * bowers-prod-env.def: Definition file to replicate jwbowers full dev env, work-in-progress.
 
 ## Reproducibility
 
-Singularity containers are not strictly reproducible. This is because during build they include timestamps in some of the metadata. Therefore the SHA hashes will differ between each build. Beyond that, it is not guaranteed that system packages will always be the same version between builds, e.g., apt packages could be patched, etc. One safeguard is to bootstrap from a particular image hash and not from a tag such as :latest. 
+Apptainer containers are not strictly reproducible. This is because during build they include timestamps in some of the metadata. Therefore the SHA hashes will differ between each build. Beyond that, it is not guaranteed that system packages will always be the same version between builds, e.g., apt packages could be patched, etc. One safeguard is to bootstrap from a particular image hash and not from a tag such as :latest. 
 
 One safeguard is to use exact package versions where possible, which this definition does by using the conda list -e output.
 
@@ -17,16 +17,16 @@ Because they use the actual hardware and OS kernel from the host machine, this c
 It is considered best practice to share both the .def and the .sif. Currently, a .sif is available on the ICC in the project directory.
 
 ## Sandbox for Local Development
-Containers aren't normally modifiable because they are often meant to replicate a set environment for reproducing on other resources. A compromise approach is to build a sandbox version of the container. 
+Containers aren't normally modifiable because they are often meant to replicate a set environment for reproducing on other resources. A compromise approach is to build a sandbox version of the container. Sandboxes can be built on the Illinois Campus Cluster on a login-node without root privileges provided one builds in `/tmp`.
 
-`$ sudo singularity build --sandbox mysandbox minimal.def`
+`$ apptainer build --sandbox /tmp/<unique sandbox name> minimal.def`
 
 or, more elaborately:
 
-`$ time sudo singularity build --sandbox mysandbox minimal.def 2>&1 | tee build.out`
+`$ time sudo apptainer build --sandbox /tmp/<unique sandbox name> minimal.def 2>&1 | tee build.out`
 
-Instead of creating a .sif, this will make a directory `mysandbox/`. This can be `cd`'d into to look around, but shouldn't be modified directly. To use the sandbox, launch with `start-sandbox.sh` which is a wrapper around `sudo singularity shell` which binds the manytestsr and test_performance_sims repos to `/mnt/manytestsr` and `/mnt/test_performance_sims`, respectively.
+Instead of creating a .sif, this will make a directory `<unique sandbox name>/`. This can be `cd`'d into to look around, but shouldn't be modified directly. To use the sandbox, launch with `start-sandbox.sh` which is a wrapper around `sudo apptainer shell` which binds the manytestsr and test_performance_sims repos to `/mnt/manytestsr` and `/mnt/test_performance_sims`, respectively.
 
 ## Image File for Production
 
-To build for production use on a cluster, don't use `--sandbox mysandbox`. The output will be a binary-blob `minimal.sif` which can be copied to the cluster.
+To build for production use, don't use `--sandbox`. The output will be a binary-blob `minimal.sif`.


### PR DESCRIPTION
In the original project, I wasn't able to build the container on the CC because I was bootstraping from library instead of docker. Once I figured that out I verified everything could build as expected on the CC.